### PR TITLE
Add stdout capture, graceful shutdowns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+store/**/*.log
+store/**/*.lock

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,14 @@
 {
-  "editor.defaultFormatter": "denoland.vscode-deno"
+  "[typescript]": {
+    "editor.defaultFormatter": "denoland.vscode-deno"
+  },
+  "[typescriptreact]": {
+    "editor.defaultFormatter": "denoland.vscode-deno"
+  },
+  "[markdown]": {
+    "editor.defaultFormatter": "denoland.vscode-deno"
+  },
+  "[json]": {
+    "editor.defaultFormatter": "denoland.vscode-deno"
+  }
 }

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "tasks": {
-    "dev": "deno run -A --watch supervisor.ts"
+    "dev": "deno run -A --watch=src/bootstrap.ts user.ts"
   },
   "imports": {
     "@std/assert": "jsr:@std/assert@1"

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -3,6 +3,23 @@
 const port = Deno.args[0];
 const script = Deno.args[1];
 
+{
+  const oldLog = console.log;
+  const oldInfo = console.info;
+  const oldWarn = console.warn;
+  const oldError = console.error;
+  console.log = (...data) =>
+    oldLog(`LOG  [${new Date().toISOString()}]`, ...data);
+  console.info = (...data) =>
+    oldInfo(`INFO [${new Date().toISOString()}]`, ...data);
+  console.warn = (...data) =>
+    oldWarn(`WARN [${new Date().toISOString()}]`, ...data);
+  console.error = (...data) =>
+    oldError(`ERROR [${new Date().toISOString()}]`, ...data);
+  // Ensure console can't be further modified
+  Object.freeze(console);
+}
+
 if (!port) {
   throw new Error("Port is required");
 }

--- a/src/supervisor.ts
+++ b/src/supervisor.ts
@@ -16,6 +16,14 @@ class Worker {
       ],
       stdout: "piped",
     }).spawn();
+
+    // Setup logging
+    const logFile = Deno.openSync(`store/${this.name}/stdout.log`, {
+      write: true,
+      create: true,
+    });
+    this.#process.stdout.pipeTo(logFile.writable);
+
     this.#process.status.then(() => {
       this.#running = false;
     });

--- a/user.ts
+++ b/user.ts
@@ -16,7 +16,10 @@ await supervisor.load(
 
 await supervisor.load(
   "test2",
-  `export default function main() {return Response.json({"test": "no"});}`,
+  `export default function main() {
+    console.log("test2");
+    return Response.json({"test": "no"});
+   }`,
 );
 
 await supervisor.load(
@@ -25,11 +28,11 @@ await supervisor.load(
 );
 
 Deno.addSignalListener("SIGINT", async () => {
-    await supervisor.shutdown();
-    Deno.exit(0);
+  await supervisor.shutdown();
+  Deno.exit(0);
 });
 
 Deno.addSignalListener("SIGTERM", async () => {
-    await supervisor.shutdown();
-    Deno.exit(0);
+  await supervisor.shutdown();
+  Deno.exit(0);
 });

--- a/user.ts
+++ b/user.ts
@@ -23,3 +23,13 @@ await supervisor.load(
   "test3",
   `export default function main() {return fetch("https://example.com")}`,
 );
+
+Deno.addSignalListener("SIGINT", async () => {
+    await supervisor.shutdown();
+    Deno.exit(0);
+});
+
+Deno.addSignalListener("SIGTERM", async () => {
+    await supervisor.shutdown();
+    Deno.exit(0);
+});


### PR DESCRIPTION
This does a few things:
- Makes a few minor config changes (documented in [the commit](https://github.com/zephraph/deno-faas/pull/5/commits/6cb66e07bbd8b791d81f1cf5add8768f05d1ee56))
- Adds a way to gracefully shutdown the supervisor and workers
- Forwards stdout from each script to its own log file